### PR TITLE
Performance optimization of `writeVertices` and `writeIndices`

### DIFF
--- a/io_xplane2blender/xplane_types/xplane_mesh.py
+++ b/io_xplane2blender/xplane_types/xplane_mesh.py
@@ -2,8 +2,6 @@ import array
 import time
 import re
 
-import cProfile, pstats, io
-
 import bpy
 from ..xplane_config import getDebug
 from ..xplane_helpers import floatToStr, logger


### PR DESCRIPTION
This performance patch specifically targets the two write methods, as discussed in some of the performance issues. It takes roughly 20% off the processing time.

The code is very much optimized for performance based on profiling data. I think this is the maximum possible in these two functions without a complete overhaul (for example, trying a streaming approach with pipes or similar for the entire export pipeline instead of first generating _all_ vertex and index data in memory).

**WARNING**
There is a minimal chance in rounding behavior on the vertices. Python switched to a different rounding algorithm going from 2.x to 3.x, which rounds .5 values 'to the even side' instead of 'up'. This rounding method however is considerably slower than the traditional one. 
The tradeoff however, is that this has a minimal effect on the output. If you agree with this approach, then we might need to tweak the expected result of some of the tests to match this.