### PR TITLE
Initial 50% optimization of animation processing

### DIFF
--- a/io_xplane2blender/xplane_types/xplane_keyframe.py
+++ b/io_xplane2blender/xplane_types/xplane_keyframe.py
@@ -107,7 +107,6 @@ class XPlaneKeyframe():
             assert isinstance(self.rotation, mathutils.Euler)
 
         self.scale = copy.copy(blenderObject.scale)
-        bpy.context.scene.frame_set(frame=currentFrame)
 
     def __str__(self)->str:
         # TODO: We aren't printing out the bone, or saving it, because we haven't solved the deepcopy


### PR DESCRIPTION
Related to #462 

Resetting the current frame for each keyframe for each object is a huge overhead (about 50% of the total time it takes to process _all_ animations).