### PR TITLE
Fix: importer branch does not load on Blender 3.3

### DIFF
--- a/io_xplane2blender/__init__.py
+++ b/io_xplane2blender/__init__.py
@@ -48,7 +48,7 @@ else:
     xplane_ui      = importlib.reload(xplane_ui)
     xplane_props   = importlib.reload(xplane_props)
     xplane_export  = importlib.reload(xplane_export)
-    xplane_import  = improtlib.reload(xplane_import)
+    xplane_import  = importlib.reload(xplane_import)
     xplane_ops     = importlib.reload(xplane_ops)
     xplane_ops_dev = importlib.reload(xplane_ops_dev)
     xplane_config  = importlib.reload(xplane_config)

--- a/io_xplane2blender/tests/__init__.py
+++ b/io_xplane2blender/tests/__init__.py
@@ -12,7 +12,7 @@ import sys
 import unittest
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
-from collections import Iterable
+from collections.abc import Iterable
 import re
 from dataclasses import dataclass
 


### PR DESCRIPTION
The `feat_importer` branch produces an addon that fails to load in Blender 3.3 LTS. You install it, then you try to enable it, and it fails. This is caused by two problems:

1. A typo in the main addon's `__init__.py`
2. The `Iterable` class was moved to `collections.abc` in Python 3.3.

This PR addresses these two trivial issues. I have tested that the resulting addon starts both in Blender 2.80 and  3.3.1 LTS.

The second point mentioned above is directly related to #708, which looks like it is already addressed in `master` and could be closed.