### PR TITLE
Fix: importer fails to import a basic obj in Blender 3.3.1 LTS

### DIFF
--- a/io_xplane2blender/importer/xplane_imp_cmd_builder.py
+++ b/io_xplane2blender/importer/xplane_imp_cmd_builder.py
@@ -284,7 +284,6 @@ class IntermediateDatablock:
             else:
                 pass
         idxes = [vertex_map_old_to_new[idx] for idx in mesh_idxes]
-        normals = [(v.nx, v.ny, v.nz) for v in vertices]
         uvs = [Vector((v.s, v.t)) for v in vertices]
 
         # Thanks senderle, https://stackoverflow.com/a/22045226
@@ -308,9 +307,6 @@ class IntermediateDatablock:
 
             for mesh_uv_loop, mesh_loop in zip(me.uv_layers[-1].data, me.loops):
                 mesh_uv_loop.uv = uvs[mesh_loop.vertex_index]
-
-            for i, vertex in enumerate(me.vertices):
-                vertex.normal = normals[i]
 
             me.calc_normals()
             me.update(calc_edges=True)


### PR DESCRIPTION
Trying to import basic geometry is failing in Blender 3.3.1 LTS. The script casts an exception saying that MeshVertex's `normal` property is readonly.

Sure enough, the property has become readonly. Moreover, writing to it was not doing much before the change either, apparently. See this discussion: [Make vertex normal property readonly](https://developer.blender.org/D14696)

This PR removes the offending lines. I have tested to import a number of objects of varying complexity in Blender 2.80 and Blender 3.3.1 LTS, including objects with normals pointing inwards. I have not noticed any problem with the change.

The discussion I linked above also talks about `calc_normals()`. I have not touched it, but you may want to take a look.