### PR TITLE
Fix: dataref keyframes not imported correctly

### DIFF
--- a/io_xplane2blender/tests/test_creation_helpers.py
+++ b/io_xplane2blender/tests/test_creation_helpers.py
@@ -922,6 +922,7 @@ def set_animation_data(
 
     for kf_info in keyframe_infos:
         bpy.context.scene.frame_current = kf_info.idx
+        bpy.context.view_layer.update()
 
         if (
             kf_info.dataref_anim_type == ANIM_TYPE_SHOW


### PR DESCRIPTION
The importer is not being able to bring in dataref value animations. It does create keyframes for them, but the value of the first keyframe is replicated to all the others, effectively loosing all the dataref animations.

The root cause has to do with the mechanisms documented here: [No updates after setting values](https://docs.blender.org/api/current/info_gotcha.html#no-updates-after-setting-values)

What happens in the addon is that the values are correctly read, but the following call:
```py
bpy.ops.object.add_xplane_dataref_keyframe(
    {"object": blender_struct}, index=dataref_index
)
```
triggers an internal `view_layer.update()`. This update happens before the control reaches the `add_xplane_dataref_keyframe` function, it is internal to Blender's machinery. The effect of the call is to reset the object to what was set in the previous keyframe. Therefore, the state of the first keyframe propagates to all that follow.

The proposed fix is to call `view_layer.update()` before writing the new keyframe information to `blender_struct`. This seems to work.
