### PR TITLE
Update xplane_props.py

### DIFF
--- a/io_xplane2blender/xplane_props.py
+++ b/io_xplane2blender/xplane_props.py
@@ -574,7 +574,7 @@ class XPlaneDataref(bpy.types.PropertyGroup):
     loop: bpy.props.FloatProperty(
         name = "Loop Animation Every",
         description = "Loop amount of animation, useful for ever increasing Datarefs. A value of 0 will ignore this setting",
-        min = 0.0,
+        #min = 0.0,
         precision = 3
     )
 


### PR DESCRIPTION
Commented out the line `min = 0.0` under the Loop Animation Entry, to allow for negative values, as requested by developer over slack.