### PR TITLE
Fixed AttributeError when exporting object with draped normal map decal 1 set

### DIFF
--- a/io_xplane2blender/xplane_types/xplane_header.py
+++ b/io_xplane2blender/xplane_types/xplane_header.py
@@ -762,7 +762,7 @@ class XPlaneHeader:
 
                 if self.xplaneFile.options.file_draped_normal_decal1 != "":
                     try:
-                        if self.xplaneFile.draped_normal_decal1_projected:
+                        if self.xplaneFile.options.draped_normal_decal1_projected:
                             if self.attributes[XPlaneAttributeName("NORMAL_DECAL_PARAMS_PROJ", 2)].getValue() == None:
                                 self.attributes[XPlaneAttributeName("NORMAL_DECAL_PARAMS_PROJ", 2)].removeValues()
                                 


### PR DESCRIPTION
## Summary:
Fixed objects failing to export when draped normal map decal 1 is set. This fixes the issue ["Draped normal map decal 1 causes objects to fail to export #744"](https://github.com/X-Plane/XPlane2Blender/issues/744)

## Detailed changes:
Line 765 of xplane_header was attempting to access `self.xplaneFile.draped_normal_decal1_projected`, however `draped_normal_decal1_projected` exists in `xplaneFile.options`, not directly in `xplaneFile`. 

This pull request changes line xplane_header 765 to properly access `self.xplaneFile.options.draped_normal_decal1_projected` instead. This is consistent with the rest of the decal code.

## Testing:
No unit tests were run, however I tested exporting objects with draped normal map decals, they exported correctly, and were loaded, and displayed correctly in sim.