### PR TITLE
Feature: Specify Relative Directory Without Specifying Filename

### DIFF
--- a/io_xplane2blender/xplane_types/xplane_file.py
+++ b/io_xplane2blender/xplane_types/xplane_file.py
@@ -126,7 +126,17 @@ def createFileFromBlenderRootObject(
     # Name change, we're now confirmed exportable!
     exportable_root = potential_root
     layer_props = exportable_root.xplane.layer
-    filename = layer_props.name if layer_props.name else exportable_root.name
+
+    #If there is a name that does *not* end in a dir sep, we use that as the file name.
+    #If a name ends in a dir sep, we treat it as a relative dir, and *append* the root col/obj name to the end
+    #If no name is specified, we just use the root col/obj name
+    filename: str
+    if layer_props.name and not (layer_props.name.endswith("\\") or layer_props.name.endswith("/")):
+        filename = layer_props.name
+    elif layer_props.name:
+        filename = layer_props.name + exportable_root.name
+    else:
+        filename = exportable_root.name
 
     xplane_file = XPlaneFile(filename, layer_props)
     xplane_file.create_xplane_bone_hiearchy(exportable_root)


### PR DESCRIPTION
# Summary:

This pull request allows users to specify a just a folder to export into, vs having to also provide the filename. If only a folder is provided (determined by the name ending in a / or \), the root collection/root obj name will be appended to the specified folder. For example, if the user enters "../MyFolder/" and the collection name is "Object", the collection will be exporter to "<.blend parent dir>/../MyFolder/Object.obj"

# Detailed Changes:

#### xplane_file.py
- Changed name setting logic to first check if the name ends in / or \, and if so, use the name with the root col/obj name appended. Otherwise check if the name is not empty, if so use it, otherwise using the root col/obj name (as the previous logic did)

# Testing:

Unit tests were run on 4.11, with the same pass/fails as the current version of XP2B. No new unit tests were added, however I manually verified the file exports to the correct path when a relative directory is specified, when a filename is specified, and when no name is specified.