### PR TITLE
Fix: Material Incompatibility Errors and Misconfiguration when Exporting Collections with Hierarchies That Span Collections

### DIFF
--- a/io_xplane2blender/xplane_types/xplane_file.py
+++ b/io_xplane2blender/xplane_types/xplane_file.py
@@ -706,6 +706,7 @@ class XPlaneFile:
                 xplaneObject.type == "MESH"
                 and xplaneObject.material
                 and xplaneObject.material.options
+                and not xplaneObject.export_animation_only
             ):
                 materials.append(xplaneObject.material)
 


### PR DESCRIPTION
# Original Issue
When exporting an object with a hierarchy that spans multiple collections/root objects, material compatibility checks can behave incorrectly:
- If the materials are considered incompatible for a single X‑Plane object (i.e. different alpha clip levels in an instanced object), the exporter throws an error.
- If the materials are considered compatible (either due to correct settings or because the export type is the less strict scenery object), the exporter may choose the wrong "reference material", resulting in wrong material settings being exported.

An example of this is if object B is a child of object A, but they reside in different collections. 
# Fix
The animation and geometry exporters already handle this case correctly by checking xplaneObject.export_animation_only when iterating over the bone tree.

I updated xplaneFile.getMaterials to also check xplaneObject.export_animation_only is false, bringing it's behavior in-line with mesh.collectXPlaneObjects.
# Detailed Changes
#### xplane_file.py
- Added a check ensuring that objects marked export_animation_only are ignored in xplaneFile.getMaterials.
# Testing
- Ran test suite on 4.11 with identical pass/fail results to the current XP2B version.
- Performed manual testing on complex shared‑root hierarchies to confirming no errors are thrown, and material settings a properly exported for each object
