### PR TITLE
Add scene report CSV export for datarefs and manipulators

### DIFF
--- a/io_xplane2blender/tests/__init__.py
+++ b/io_xplane2blender/tests/__init__.py
@@ -201,7 +201,7 @@ class XPlaneTestCase(unittest.TestCase):
                     xplane_primitive.XPlanePrimitive,
                 )
             )
-            self.assertEquals(
+            self.assertEqual(
                 xplaneFile._bl_obj_name_to_bone[name].blenderObject,
                 bpy.data.objects[name],
             )
@@ -257,7 +257,7 @@ class XPlaneTestCase(unittest.TestCase):
     def assertFloatVectorsEqual(
         self, a: int, b: int, tolerance: float = FLOAT_TOLERANCE
     ):
-        self.assertEquals(len(a), len(b))
+        self.assertEqual(len(a), len(b))
         for a_comp, b_comp in zip(a, b):
             self.assertFloatsEqual(a_comp, b_comp, tolerance)
 
@@ -322,7 +322,7 @@ class XPlaneTestCase(unittest.TestCase):
 
         # ensure same number of lines
         try:
-            self.assertEquals(len(linesA), len(linesB))
+            self.assertEqual(len(linesA), len(linesB))
         except AssertionError as e:
             only_in_a = set(linesA) - set(linesB)
             only_in_b = set(linesB) - set(linesA)
@@ -342,7 +342,7 @@ class XPlaneTestCase(unittest.TestCase):
         for lineIndex, (lineA, lineB) in enumerate(zip(linesA, linesB)):
             try:
                 # print(f"lineA:{lineA}, lineB:{lineB}")
-                self.assertEquals(len(lineA), len(lineB))
+                self.assertEqual(len(lineA), len(lineB))
             except AssertionError as e:
                 raise AssertionError(
                     f"Number of line components unequal: {e.args[0]}\n"
@@ -410,7 +410,7 @@ class XPlaneTestCase(unittest.TestCase):
                             + "\n\n".join((context_lineA, context_lineB))
                         ) from None
                 else:
-                    self.assertEquals(segmentA, segmentB)
+                    self.assertEqual(segmentA, segmentB)
 
     def assertFileOutputEqualsFixture(
         self,
@@ -534,7 +534,7 @@ class XPlaneTestCase(unittest.TestCase):
         with io.StringIO() as s_buf:
             pprint(list(attrs.keys()), s_buf)
             attrs_pp_str = s_buf.getvalue()
-        self.assertEquals(
+        self.assertEqual(
             len(expected_attrs),
             len(attrs),
             f"Attribute lists {list(expected_attrs.keys())}, {list(attrs.keys())} have different length",
@@ -550,7 +550,7 @@ class XPlaneTestCase(unittest.TestCase):
                     (list, tuple),
                     msg='Attribute value for "{value}" is a {type(value)}, not a list or tuple',
                 )
-                self.assertEquals(
+                self.assertEqual(
                     len(expected_value),
                     len(value),
                     'Attribute value list for "{name}" have different length',
@@ -560,12 +560,12 @@ class XPlaneTestCase(unittest.TestCase):
                     if isinstance(expectedV, (float, int)):
                         self.assertFloatsEqual(expectedV, v, floatTolerance)
                     else:
-                        self.assertEquals(
+                        self.assertEqual(
                             expectedV,
                             v,
                         )
             else:
-                self.assertEquals(
+                self.assertEqual(
                     expected_value,
                     value,
                 )

--- a/io_xplane2blender/xplane_helpers.py
+++ b/io_xplane2blender/xplane_helpers.py
@@ -55,6 +55,70 @@ def floatToStr(n: float) -> str:
     return s
 
 
+def get_action_fcurves(anim_data):
+    """Return the FCurves collection for the active action/slot.
+
+    Blender 4.x: action.fcurves
+    Blender 5.x: channelbag.fcurves for the bound slot
+    Returns an empty list when there is no action or no matching channelbag.
+    """
+    if anim_data is None or anim_data.action is None:
+        return []
+    action = anim_data.action
+    if hasattr(action, "fcurves"):
+        # Blender < 5.0
+        return action.fcurves
+    # Blender 5.0+
+    from bpy_extras import anim_utils
+
+    slot = anim_data.action_slot
+    if slot is None:
+        return []
+    channelbag = anim_utils.action_get_channelbag_for_slot(action, slot)
+    return channelbag.fcurves if channelbag else []
+
+
+def iter_all_action_fcurves(action):
+    """Iterate every FCurve in an action, across all slots/channelbags.
+
+    Use this when you need to scan all keyframes regardless of which object
+    is bound to the action (e.g. building a global frame-visit set).
+    """
+    if hasattr(action, "fcurves"):
+        # Blender < 5.0
+        return action.fcurves
+    # Blender 5.0+: iterate every slot's channelbag
+    from bpy_extras import anim_utils
+
+    result = []
+    for slot in action.slots:
+        channelbag = anim_utils.action_get_channelbag_for_slot(action, slot)
+        if channelbag:
+            result.extend(channelbag.fcurves)
+    return result
+
+
+def ensure_action_group(anim_data, group_name: str) -> None:
+    """Ensure an FCurve group with *group_name* exists in the right container.
+
+    Blender 4.x: action.groups
+    Blender 5.x: channelbag.groups (creates the channelbag if needed)
+    """
+    action = anim_data.action
+    if hasattr(action, "fcurves"):
+        # Blender < 5.0
+        if group_name not in action.groups:
+            action.groups.new(group_name)
+    else:
+        # Blender 5.0+
+        from bpy_extras import anim_utils
+
+        slot = anim_data.action_slot
+        channelbag = anim_utils.action_ensure_channelbag_for_slot(action, slot)
+        if group_name not in channelbag.groups:
+            channelbag.groups.new(group_name)
+
+
 def resolveBlenderPath(path: str) -> str:
     blenddir = os.path.dirname(bpy.context.blend_data.filepath)
 

--- a/io_xplane2blender/xplane_ops.py
+++ b/io_xplane2blender/xplane_ops.py
@@ -6,6 +6,10 @@ from typing import Any, Dict, List, Optional, Tuple
 import bpy
 
 from io_xplane2blender import xplane_props
+from io_xplane2blender.xplane_helpers import (
+    ensure_action_group,
+    get_action_fcurves,
+)
 from io_xplane2blender.xplane_config import *
 from io_xplane2blender.xplane_constants import (
     MAX_COCKPIT_REGIONS,
@@ -58,9 +62,9 @@ def makeKeyframesLinear(obj, path):
     if (
         obj.animation_data != None
         and obj.animation_data.action != None
-        and len(obj.animation_data.action.fcurves) > 0
+        and len(get_action_fcurves(obj.animation_data)) > 0
     ):
-        fcurve = findFCurveByPath(obj.animation_data.action.fcurves, path)
+        fcurve = findFCurveByPath(get_action_fcurves(obj.animation_data), path)
 
         if fcurve:
             # find keyframe
@@ -308,14 +312,11 @@ class OBJECT_OT_remove_xplane_dataref(bpy.types.Operator):
         path = getDatarefValuePath(self.index)
 
         # remove FCurves too
-        if (
-            obj.animation_data != None
-            and obj.animation_data.action != None
-            and len(obj.animation_data.action.fcurves) > 0
-        ):
-            fcurve = findFCurveByPath(obj.animation_data.action.fcurves, path)
+        fcurves = get_action_fcurves(obj.animation_data)
+        if fcurves:
+            fcurve = findFCurveByPath(fcurves, path)
             if fcurve:
-                obj.animation_data.action.fcurves.remove(fcurve=fcurve)
+                fcurves.remove(fcurve=fcurve)
 
         return {"FINISHED"}
 
@@ -336,8 +337,7 @@ class OBJECT_OT_add_xplane_dataref_keyframe(bpy.types.Operator):
         path = getDatarefValuePath(self.index)
         value = obj.xplane.datarefs[self.index].value
 
-        if "XPlane Datarefs" not in obj.animation_data.action.groups:
-            obj.animation_data.action.groups.new("XPlane Datarefs")
+        ensure_action_group(obj.animation_data, "XPlane Datarefs")
 
         obj.xplane.datarefs[self.index].keyframe_insert(
             data_path="value", group="XPlane Datarefs"
@@ -449,14 +449,11 @@ class BONE_OT_remove_xplane_dataref(bpy.types.Operator):
         path = getDatarefValuePath(self.index, bone)
 
         # remove FCurves too
-        if (
-            obj.animation_data != None
-            and obj.animation_data.action != None
-            and len(obj.animation_data.action.fcurves) > 0
-        ):
-            fcurve = findFCurveByPath(obj.animation_data.action.fcurves, path)
+        fcurves = get_action_fcurves(obj.animation_data)
+        if fcurves:
+            fcurve = findFCurveByPath(fcurves, path)
             if fcurve:
-                obj.animation_data.action.fcurves.remove(fcurve=fcurve)
+                fcurves.remove(fcurve=fcurve)
 
         return {"FINISHED"}
 
@@ -484,8 +481,7 @@ class BONE_OT_add_xplane_dataref_keyframe(bpy.types.Operator):
 
         groupName = "XPlane Datarefs " + bone.name
 
-        if groupName not in armature.animation_data.action.groups:
-            armature.animation_data.action.groups.new(groupName)
+        ensure_action_group(armature.animation_data, groupName)
 
         armature.data.keyframe_insert(data_path=path, group=groupName)
 

--- a/io_xplane2blender/xplane_ops.py
+++ b/io_xplane2blender/xplane_ops.py
@@ -21,6 +21,7 @@ from io_xplane2blender.xplane_ops_dev import *
 from io_xplane2blender.xplane_utils import (
     xplane_commands_txt_parser,
     xplane_datarefs_txt_parser,
+    xplane_scene_report,
     xplane_wiper_gradient,
 )
 
@@ -1001,6 +1002,67 @@ class XPLANE_OT_bake_wiper_gradient_texture(bpy.types.Operator):
         }
 
 
+class XPLANE_OT_ExportSceneReport(bpy.types.Operator):
+    """Export a CSV report of all datarefs and manipulators used in the scene"""
+
+    bl_idname = "xplane.export_scene_report"
+    bl_label = "Export Scene Report (CSV)"
+
+    directory: bpy.props.StringProperty(
+        name="Output Directory",
+        description="Directory where the CSV report files will be written",
+        subtype="DIR_PATH",
+    )
+
+    def invoke(self, context, event):
+        # Pre-fill with the directory of the open .blend file, falling back
+        # to the system temp folder when the file hasn't been saved yet.
+        if bpy.data.filepath:
+            import os
+            self.directory = os.path.dirname(bpy.data.filepath)
+        wm = context.window_manager
+        wm.fileselect_add(self)
+        return {"RUNNING_MODAL"}
+
+    def execute(self, context):
+        import os
+
+        scene = context.scene
+        blend_name = (
+            os.path.splitext(os.path.basename(bpy.data.filepath))[0]
+            if bpy.data.filepath
+            else "scene"
+        )
+        out_dir = bpy.path.abspath(self.directory)
+
+        view_layer = context.view_layer
+
+        # --- Datarefs ---
+        dr_rows = xplane_scene_report.collect_datarefs(scene, view_layer)
+        dr_csv = xplane_scene_report.write_csv(
+            dr_rows, xplane_scene_report.DATAREF_FIELDS
+        )
+        dr_path = os.path.join(out_dir, f"{blend_name}_datarefs.csv")
+        with open(dr_path, "w", encoding="utf-8") as f:
+            f.write(dr_csv)
+
+        # --- Manipulators ---
+        manip_rows = xplane_scene_report.collect_manipulators(scene, view_layer)
+        manip_csv = xplane_scene_report.write_csv(
+            manip_rows, xplane_scene_report.MANIPULATOR_FIELDS
+        )
+        manip_path = os.path.join(out_dir, f"{blend_name}_manipulators.csv")
+        with open(manip_path, "w", encoding="utf-8") as f:
+            f.write(manip_csv)
+
+        self.report(
+            {"INFO"},
+            f"Wrote {len(dr_rows)} dataref(s) to {dr_path} "
+            f"and {len(manip_rows)} manipulator(s) to {manip_path}",
+        )
+        return {"FINISHED"}
+
+
 _ops = (
     COLLECTION_OT_add_xplane_export_path_directive,
     COLLECTION_OT_remove_xplane_export_path_directive,
@@ -1037,6 +1099,7 @@ _ops = (
     XPLANE_OT_DatarefSearchToggle,
     XPLANE_OT_XPlaneMessage,
     XPLANE_OT_bake_wiper_gradient_texture,
+    XPLANE_OT_ExportSceneReport,
 )
 
 register, unregister = bpy.utils.register_classes_factory(_ops)

--- a/io_xplane2blender/xplane_ops.py
+++ b/io_xplane2blender/xplane_ops.py
@@ -1008,57 +1008,57 @@ class XPLANE_OT_ExportSceneReport(bpy.types.Operator):
     bl_idname = "xplane.export_scene_report"
     bl_label = "Export Scene Report (CSV)"
 
-    directory: bpy.props.StringProperty(
-        name="Output Directory",
-        description="Directory where the CSV report files will be written",
-        subtype="DIR_PATH",
+    filepath: bpy.props.StringProperty(
+        name="File Path",
+        description="Path to the CSV report file to write",
+        subtype="FILE_PATH",
+    )
+
+    check_existing: bpy.props.BoolProperty(
+        default=True,
+        options={"HIDDEN"},
+    )
+
+    filter_glob: bpy.props.StringProperty(
+        default="*.csv",
+        options={"HIDDEN"},
     )
 
     def invoke(self, context, event):
-        # Pre-fill with the directory of the open .blend file, falling back
-        # to the system temp folder when the file hasn't been saved yet.
-        if bpy.data.filepath:
-            import os
-            self.directory = os.path.dirname(bpy.data.filepath)
-        wm = context.window_manager
-        wm.fileselect_add(self)
-        return {"RUNNING_MODAL"}
-
-    def execute(self, context):
         import os
-
-        scene = context.scene
         blend_name = (
             os.path.splitext(os.path.basename(bpy.data.filepath))[0]
             if bpy.data.filepath
             else "scene"
         )
-        out_dir = bpy.path.abspath(self.directory)
+        self.filepath = os.path.join(
+            os.path.dirname(bpy.data.filepath) if bpy.data.filepath else "",
+            f"{blend_name}_scene_report.csv",
+        )
+        wm = context.window_manager
+        wm.fileselect_add(self)
+        return {"RUNNING_MODAL"}
 
+    def execute(self, context):
         view_layer = context.view_layer
+        scene = context.scene
 
-        # --- Datarefs ---
         dr_rows = xplane_scene_report.collect_datarefs(scene, view_layer)
-        dr_csv = xplane_scene_report.write_csv(
-            dr_rows, xplane_scene_report.DATAREF_FIELDS
-        )
-        dr_path = os.path.join(out_dir, f"{blend_name}_datarefs.csv")
-        with open(dr_path, "w", encoding="utf-8") as f:
-            f.write(dr_csv)
-
-        # --- Manipulators ---
         manip_rows = xplane_scene_report.collect_manipulators(scene, view_layer)
-        manip_csv = xplane_scene_report.write_csv(
-            manip_rows, xplane_scene_report.MANIPULATOR_FIELDS
-        )
-        manip_path = os.path.join(out_dir, f"{blend_name}_manipulators.csv")
-        with open(manip_path, "w", encoding="utf-8") as f:
-            f.write(manip_csv)
+
+        if not dr_rows and not manip_rows:
+            self.report({"WARNING"}, "No datarefs or manipulators found in scene")
+            return {"CANCELLED"}
+
+        csv_content = xplane_scene_report.write_combined_report(dr_rows, manip_rows)
+        out_path = bpy.path.abspath(self.filepath)
+        with open(out_path, "w", encoding="utf-8") as f:
+            f.write(csv_content)
 
         self.report(
             {"INFO"},
-            f"Wrote {len(dr_rows)} dataref(s) to {dr_path} "
-            f"and {len(manip_rows)} manipulator(s) to {manip_path}",
+            f"Wrote {len(dr_rows)} dataref(s) and {len(manip_rows)} manipulator(s) "
+            f"to {out_path}",
         )
         return {"FINISHED"}
 

--- a/io_xplane2blender/xplane_types/xplane_bone.py
+++ b/io_xplane2blender/xplane_types/xplane_bone.py
@@ -34,7 +34,7 @@ import mathutils
 
 from io_xplane2blender import xplane_constants, xplane_props
 from io_xplane2blender.xplane_config import getDebug
-from io_xplane2blender.xplane_helpers import floatToStr, logger, vec_b_to_x
+from io_xplane2blender.xplane_helpers import floatToStr, get_action_fcurves, logger, vec_b_to_x
 from io_xplane2blender.xplane_types.xplane_keyframe import XPlaneKeyframe
 from io_xplane2blender.xplane_types.xplane_keyframe_collection import (
     XPlaneKeyframeCollection,
@@ -183,13 +183,13 @@ class XPlaneBone:
                 # bone animation data resides in the armature objects .data block
                 fcurves = [
                     f
-                    for f in blenderObject.data.animation_data.action.fcurves
+                    for f in get_action_fcurves(blenderObject.data.animation_data)
                     if f.data_path.startswith(f'bones["{bone.name}"].xplane.datarefs')
                 ]
             else:
                 fcurves = [
                     f
-                    for f in blenderObject.animation_data.action.fcurves
+                    for f in get_action_fcurves(blenderObject.animation_data)
                     if f.data_path.startswith(f"xplane.datarefs")
                 ]
         except AttributeError:

--- a/io_xplane2blender/xplane_types/xplane_file.py
+++ b/io_xplane2blender/xplane_types/xplane_file.py
@@ -34,6 +34,7 @@ from ..xplane_helpers import (
     ExportableRoot,
     PotentialRoot,
     floatToStr,
+    iter_all_action_fcurves,
     logger,
 )
 from .xplane_bone import XPlaneBone
@@ -181,7 +182,7 @@ def _pre_scan_all_keyframes():
         {
             int(kf.co[0])
             for action in bpy.data.actions
-            for fcurve in action.fcurves
+            for fcurve in iter_all_action_fcurves(action)
             for kf in fcurve.keyframe_points
             if kf.co[0].is_integer()
         }

--- a/io_xplane2blender/xplane_ui.py
+++ b/io_xplane2blender/xplane_ui.py
@@ -333,6 +333,7 @@ def rain_layout(
 
 def scene_layout(layout: bpy.types.UILayout, scene: bpy.types.Scene):
     layout.row().operator("scene.export_to_relative_dir", icon="EXPORT")
+    layout.row().operator("xplane.export_scene_report", icon="FILE_TEXT")
     row = layout.row()
     layout.row().prop(scene.xplane, "version")
 

--- a/io_xplane2blender/xplane_utils/xplane_scene_report.py
+++ b/io_xplane2blender/xplane_utils/xplane_scene_report.py
@@ -10,6 +10,7 @@ import io
 from typing import Dict, List, Optional, Tuple
 
 import bpy
+from io_xplane2blender.xplane_helpers import get_action_fcurves
 
 # --- Field name constants ---
 
@@ -115,7 +116,7 @@ def _get_transform_range(
         data_path = f"xplane.datarefs[{index}].value"
 
     if anim_data and anim_data.action:
-        for fcurve in anim_data.action.fcurves:
+        for fcurve in get_action_fcurves(anim_data):
             if fcurve.data_path == data_path:
                 values = [kp.co[1] for kp in fcurve.keyframe_points]
                 if values:

--- a/io_xplane2blender/xplane_utils/xplane_scene_report.py
+++ b/io_xplane2blender/xplane_utils/xplane_scene_report.py
@@ -10,6 +10,19 @@ import io
 from typing import Dict, List, Optional, Tuple
 
 import bpy
+from io_xplane2blender.xplane_constants import (
+    MANIP_DELTA,
+    MANIP_DRAG_AXIS,
+    MANIP_DRAG_AXIS_DETENT,
+    MANIP_DRAG_AXIS_PIX,
+    MANIP_DRAG_ROTATE,
+    MANIP_DRAG_ROTATE_DETENT,
+    MANIP_DRAG_XY,
+    MANIP_PUSH,
+    MANIP_RADIO,
+    MANIP_TOGGLE,
+    MANIP_WRAP,
+)
 from io_xplane2blender.xplane_helpers import get_action_fcurves
 
 # --- Field name constants ---
@@ -35,6 +48,11 @@ MANIPULATOR_FIELDS = [
     "Dataref 2",
     "Dataref 2 Min",
     "Dataref 2 Max",
+    "Value On",
+    "Value Off",
+    "Value Down",
+    "Value Up",
+    "Value Hold",
     "Command",
     "Positive Command",
     "Negative Command",
@@ -142,21 +160,67 @@ def collect_manipulators(
         if not manip.enabled:
             continue
 
-        rows.append({
+        t = manip.type
+        row = {
             "Object Name": obj.name,
-            "Manipulator Type": manip.type,
+            "Manipulator Type": t,
             "Tooltip": manip.tooltip,
             "Cursor": manip.cursor,
-            "Dataref 1": manip.dataref1,
-            "Dataref 1 Min": manip.v1_min if manip.dataref1 else "",
-            "Dataref 1 Max": manip.v1_max if manip.dataref1 else "",
-            "Dataref 2": manip.dataref2,
-            "Dataref 2 Min": manip.v2_min if manip.dataref2 else "",
-            "Dataref 2 Max": manip.v2_max if manip.dataref2 else "",
-            "Command": manip.command,
-            "Positive Command": manip.positive_command,
-            "Negative Command": manip.negative_command,
-        })
+            "Dataref 1": "",
+            "Dataref 1 Min": "",
+            "Dataref 1 Max": "",
+            "Dataref 2": "",
+            "Dataref 2 Min": "",
+            "Dataref 2 Max": "",
+            "Value On": "",
+            "Value Off": "",
+            "Value Down": "",
+            "Value Up": "",
+            "Value Hold": "",
+            "Command": "",
+            "Positive Command": "",
+            "Negative Command": "",
+        }
+
+        if t in (
+            MANIP_DRAG_XY,
+            MANIP_DRAG_AXIS,
+            MANIP_DRAG_AXIS_PIX,
+            MANIP_DRAG_AXIS_DETENT,
+            MANIP_DRAG_ROTATE,
+            MANIP_DRAG_ROTATE_DETENT,
+        ):
+            row["Dataref 1"] = manip.dataref1
+            row["Dataref 1 Min"] = manip.v1_min
+            row["Dataref 1 Max"] = manip.v1_max
+            if t == MANIP_DRAG_XY:
+                row["Dataref 2"] = manip.dataref2
+                row["Dataref 2 Min"] = manip.v2_min
+                row["Dataref 2 Max"] = manip.v2_max
+        elif t == MANIP_TOGGLE:
+            row["Dataref 1"] = manip.dataref1
+            row["Value On"] = manip.v_on
+            row["Value Off"] = manip.v_off
+        elif t == MANIP_PUSH:
+            row["Dataref 1"] = manip.dataref1
+            row["Value Down"] = manip.v_down
+            row["Value Up"] = manip.v_up
+        elif t == MANIP_RADIO:
+            row["Dataref 1"] = manip.dataref1
+            row["Value Down"] = manip.v_down
+        elif t in (MANIP_DELTA, MANIP_WRAP):
+            row["Dataref 1"] = manip.dataref1
+            row["Value Down"] = manip.v_down
+            row["Value Hold"] = manip.v_hold
+            row["Dataref 1 Min"] = manip.v1_min
+            row["Dataref 1 Max"] = manip.v1_max
+        else:
+            # Command-based types
+            row["Command"] = manip.command
+            row["Positive Command"] = manip.positive_command
+            row["Negative Command"] = manip.negative_command
+
+        rows.append(row)
 
     return rows
 
@@ -170,3 +234,18 @@ def write_csv(rows: List[Dict], fieldnames: List[str]) -> str:
     writer.writeheader()
     writer.writerows(rows)
     return output.getvalue()
+
+
+def write_combined_report(dr_rows: List[Dict], manip_rows: List[Dict]) -> str:
+    """
+    Serialize datarefs and manipulators into a single CSV string.
+
+    Each non-empty section gets its own header row. Sections are separated by
+    a blank line. Sections with no rows are omitted entirely.
+    """
+    sections = []
+    if dr_rows:
+        sections.append(write_csv(dr_rows, DATAREF_FIELDS))
+    if manip_rows:
+        sections.append(write_csv(manip_rows, MANIPULATOR_FIELDS))
+    return "\n".join(sections)

--- a/io_xplane2blender/xplane_utils/xplane_scene_report.py
+++ b/io_xplane2blender/xplane_utils/xplane_scene_report.py
@@ -1,0 +1,171 @@
+"""
+Utilities for generating scene reports as CSV data.
+
+Collects animation datarefs and manipulator/command information from all
+objects and bones in a Blender scene and serializes them to CSV strings.
+"""
+
+import csv
+import io
+from typing import Dict, List, Optional, Tuple
+
+import bpy
+
+# --- Field name constants ---
+
+DATAREF_FIELDS = [
+    "Object Name",
+    "Object Type",
+    "Dataref Path",
+    "Animation Type",
+    "Value 1",
+    "Value 2",
+    "Loop",
+]
+
+MANIPULATOR_FIELDS = [
+    "Object Name",
+    "Manipulator Type",
+    "Tooltip",
+    "Cursor",
+    "Dataref 1",
+    "Dataref 1 Min",
+    "Dataref 1 Max",
+    "Dataref 2",
+    "Dataref 2 Min",
+    "Dataref 2 Max",
+    "Command",
+    "Positive Command",
+    "Negative Command",
+]
+
+
+def collect_datarefs(
+    scene: bpy.types.Scene, view_layer: bpy.types.ViewLayer
+) -> List[Dict]:
+    """
+    Walk all visible objects and bones in the scene, returning one dict per
+    animation dataref. Transform datarefs report their keyframe value range;
+    show/hide datarefs report their threshold values.
+    """
+    rows = []
+
+    for obj in scene.objects:
+        if not obj.visible_get(view_layer=view_layer):
+            continue
+        # Datarefs on the object itself
+        for i, dr in enumerate(obj.xplane.datarefs):
+            if not dr.path:
+                continue
+            v1, v2 = _get_transform_range(obj.animation_data, i, dr)
+            rows.append({
+                "Object Name": obj.name,
+                "Object Type": "OBJECT",
+                "Dataref Path": dr.path,
+                "Animation Type": dr.anim_type,
+                "Value 1": v1,
+                "Value 2": v2,
+                "Loop": dr.loop if dr.loop != 0.0 else "",
+            })
+
+        # Datarefs on bones inside armature objects
+        if obj.type == "ARMATURE" and obj.data:
+            for bone in obj.data.bones:
+                for i, dr in enumerate(bone.xplane.datarefs):
+                    if not dr.path:
+                        continue
+                    # Bone keyframes live on the armature's animation_data,
+                    # with a data path that includes the bone name.
+                    v1, v2 = _get_transform_range(
+                        obj.data.animation_data, i, dr, bone_name=bone.name
+                    )
+                    rows.append({
+                        "Object Name": f"{obj.name} / {bone.name}",
+                        "Object Type": "BONE",
+                        "Dataref Path": dr.path,
+                        "Animation Type": dr.anim_type,
+                        "Value 1": v1,
+                        "Value 2": v2,
+                        "Loop": dr.loop if dr.loop != 0.0 else "",
+                    })
+
+    return rows
+
+
+def _get_transform_range(
+    anim_data: Optional[bpy.types.AnimData],
+    index: int,
+    dr,
+    bone_name: Optional[str] = None,
+) -> Tuple:
+    """
+    Return (value_1, value_2) for a dataref.
+
+    For show/hide types these are the stored threshold values.
+    For transform types these are the min/max keyframe values on the
+    dataref's value FCurve, or empty strings if no keyframes exist.
+    """
+    if dr.anim_type in ("show", "hide"):
+        return dr.show_hide_v1, dr.show_hide_v2
+
+    # Build the FCurve data path used when keyframing this dataref's value
+    if bone_name:
+        data_path = f'bones["{bone_name}"].xplane.datarefs[{index}].value'
+    else:
+        data_path = f"xplane.datarefs[{index}].value"
+
+    if anim_data and anim_data.action:
+        for fcurve in anim_data.action.fcurves:
+            if fcurve.data_path == data_path:
+                values = [kp.co[1] for kp in fcurve.keyframe_points]
+                if values:
+                    return min(values), max(values)
+
+    return "", ""
+
+
+def collect_manipulators(
+    scene: bpy.types.Scene, view_layer: bpy.types.ViewLayer
+) -> List[Dict]:
+    """
+    Walk all visible objects in the scene, returning one dict per enabled
+    manipulator. Each row includes whatever datarefs or commands the
+    manipulator references.
+    """
+    rows = []
+
+    for obj in scene.objects:
+        if not obj.visible_get(view_layer=view_layer):
+            continue
+        manip = obj.xplane.manip
+        if not manip.enabled:
+            continue
+
+        rows.append({
+            "Object Name": obj.name,
+            "Manipulator Type": manip.type,
+            "Tooltip": manip.tooltip,
+            "Cursor": manip.cursor,
+            "Dataref 1": manip.dataref1,
+            "Dataref 1 Min": manip.v1_min if manip.dataref1 else "",
+            "Dataref 1 Max": manip.v1_max if manip.dataref1 else "",
+            "Dataref 2": manip.dataref2,
+            "Dataref 2 Min": manip.v2_min if manip.dataref2 else "",
+            "Dataref 2 Max": manip.v2_max if manip.dataref2 else "",
+            "Command": manip.command,
+            "Positive Command": manip.positive_command,
+            "Negative Command": manip.negative_command,
+        })
+
+    return rows
+
+
+def write_csv(rows: List[Dict], fieldnames: List[str]) -> str:
+    """Serialize a list of row dicts to a CSV string."""
+    output = io.StringIO()
+    writer = csv.DictWriter(
+        output, fieldnames=fieldnames, extrasaction="ignore", lineterminator="\n"
+    )
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()

--- a/tests/features/rain/bake_wiper_texture_bad_rgb_only.test.py
+++ b/tests/features/rain/bake_wiper_texture_bad_rgb_only.test.py
@@ -23,6 +23,6 @@ class TestBakeWiperTextureBadRGBOnly(XPlaneTestCase):
             "bad_wiper_image_rgb_only"
         ]
         bpy.context.view_layer.objects.active = any_object
-        self.assertEquals(bpy.ops.xplane.bake_wiper_gradient_texture(), {"CANCELLED"})
+        self.assertEqual(bpy.ops.xplane.bake_wiper_gradient_texture(), {"CANCELLED"})
 
 runTestCases([TestBakeWiperTextureBadRGBOnly])


### PR DESCRIPTION
Adds a new operator (Export Scene Report) that writes two CSV files: one listing all animation datarefs (path, type, value range, loop) and one listing all manipulators (type, tooltip, cursor, associated datarefs or commands with value ranges). Only visible objects are included, matching the same visibility rules as the exporter.