### PR TITLE
Fix Blender 5.x compatibility for slotted actions API

### DIFF
--- a/io_xplane2blender/tests/__init__.py
+++ b/io_xplane2blender/tests/__init__.py
@@ -201,7 +201,7 @@ class XPlaneTestCase(unittest.TestCase):
                     xplane_primitive.XPlanePrimitive,
                 )
             )
-            self.assertEquals(
+            self.assertEqual(
                 xplaneFile._bl_obj_name_to_bone[name].blenderObject,
                 bpy.data.objects[name],
             )
@@ -257,7 +257,7 @@ class XPlaneTestCase(unittest.TestCase):
     def assertFloatVectorsEqual(
         self, a: int, b: int, tolerance: float = FLOAT_TOLERANCE
     ):
-        self.assertEquals(len(a), len(b))
+        self.assertEqual(len(a), len(b))
         for a_comp, b_comp in zip(a, b):
             self.assertFloatsEqual(a_comp, b_comp, tolerance)
 
@@ -322,7 +322,7 @@ class XPlaneTestCase(unittest.TestCase):
 
         # ensure same number of lines
         try:
-            self.assertEquals(len(linesA), len(linesB))
+            self.assertEqual(len(linesA), len(linesB))
         except AssertionError as e:
             only_in_a = set(linesA) - set(linesB)
             only_in_b = set(linesB) - set(linesA)
@@ -342,7 +342,7 @@ class XPlaneTestCase(unittest.TestCase):
         for lineIndex, (lineA, lineB) in enumerate(zip(linesA, linesB)):
             try:
                 # print(f"lineA:{lineA}, lineB:{lineB}")
-                self.assertEquals(len(lineA), len(lineB))
+                self.assertEqual(len(lineA), len(lineB))
             except AssertionError as e:
                 raise AssertionError(
                     f"Number of line components unequal: {e.args[0]}\n"
@@ -410,7 +410,7 @@ class XPlaneTestCase(unittest.TestCase):
                             + "\n\n".join((context_lineA, context_lineB))
                         ) from None
                 else:
-                    self.assertEquals(segmentA, segmentB)
+                    self.assertEqual(segmentA, segmentB)
 
     def assertFileOutputEqualsFixture(
         self,
@@ -534,7 +534,7 @@ class XPlaneTestCase(unittest.TestCase):
         with io.StringIO() as s_buf:
             pprint(list(attrs.keys()), s_buf)
             attrs_pp_str = s_buf.getvalue()
-        self.assertEquals(
+        self.assertEqual(
             len(expected_attrs),
             len(attrs),
             f"Attribute lists {list(expected_attrs.keys())}, {list(attrs.keys())} have different length",
@@ -550,7 +550,7 @@ class XPlaneTestCase(unittest.TestCase):
                     (list, tuple),
                     msg='Attribute value for "{value}" is a {type(value)}, not a list or tuple',
                 )
-                self.assertEquals(
+                self.assertEqual(
                     len(expected_value),
                     len(value),
                     'Attribute value list for "{name}" have different length',
@@ -560,12 +560,12 @@ class XPlaneTestCase(unittest.TestCase):
                     if isinstance(expectedV, (float, int)):
                         self.assertFloatsEqual(expectedV, v, floatTolerance)
                     else:
-                        self.assertEquals(
+                        self.assertEqual(
                             expectedV,
                             v,
                         )
             else:
-                self.assertEquals(
+                self.assertEqual(
                     expected_value,
                     value,
                 )

--- a/io_xplane2blender/xplane_helpers.py
+++ b/io_xplane2blender/xplane_helpers.py
@@ -55,6 +55,70 @@ def floatToStr(n: float) -> str:
     return s
 
 
+def get_action_fcurves(anim_data):
+    """Return the FCurves collection for the active action/slot.
+
+    Blender 4.x: action.fcurves
+    Blender 5.x: channelbag.fcurves for the bound slot
+    Returns an empty list when there is no action or no matching channelbag.
+    """
+    if anim_data is None or anim_data.action is None:
+        return []
+    action = anim_data.action
+    if hasattr(action, "fcurves"):
+        # Blender < 5.0
+        return action.fcurves
+    # Blender 5.0+
+    from bpy_extras import anim_utils
+
+    slot = anim_data.action_slot
+    if slot is None:
+        return []
+    channelbag = anim_utils.action_get_channelbag_for_slot(action, slot)
+    return channelbag.fcurves if channelbag else []
+
+
+def iter_all_action_fcurves(action):
+    """Iterate every FCurve in an action, across all slots/channelbags.
+
+    Use this when you need to scan all keyframes regardless of which object
+    is bound to the action (e.g. building a global frame-visit set).
+    """
+    if hasattr(action, "fcurves"):
+        # Blender < 5.0
+        return action.fcurves
+    # Blender 5.0+: iterate every slot's channelbag
+    from bpy_extras import anim_utils
+
+    result = []
+    for slot in action.slots:
+        channelbag = anim_utils.action_get_channelbag_for_slot(action, slot)
+        if channelbag:
+            result.extend(channelbag.fcurves)
+    return result
+
+
+def ensure_action_group(anim_data, group_name: str) -> None:
+    """Ensure an FCurve group with *group_name* exists in the right container.
+
+    Blender 4.x: action.groups
+    Blender 5.x: channelbag.groups (creates the channelbag if needed)
+    """
+    action = anim_data.action
+    if hasattr(action, "fcurves"):
+        # Blender < 5.0
+        if group_name not in action.groups:
+            action.groups.new(group_name)
+    else:
+        # Blender 5.0+
+        from bpy_extras import anim_utils
+
+        slot = anim_data.action_slot
+        channelbag = anim_utils.action_ensure_channelbag_for_slot(action, slot)
+        if group_name not in channelbag.groups:
+            channelbag.groups.new(group_name)
+
+
 def resolveBlenderPath(path: str) -> str:
     blenddir = os.path.dirname(bpy.context.blend_data.filepath)
 

--- a/io_xplane2blender/xplane_ops.py
+++ b/io_xplane2blender/xplane_ops.py
@@ -6,6 +6,10 @@ from typing import Any, Dict, List, Optional, Tuple
 import bpy
 
 from io_xplane2blender import xplane_props
+from io_xplane2blender.xplane_helpers import (
+    ensure_action_group,
+    get_action_fcurves,
+)
 from io_xplane2blender.xplane_config import *
 from io_xplane2blender.xplane_constants import (
     MAX_COCKPIT_REGIONS,
@@ -58,9 +62,9 @@ def makeKeyframesLinear(obj, path):
     if (
         obj.animation_data != None
         and obj.animation_data.action != None
-        and len(obj.animation_data.action.fcurves) > 0
+        and len(get_action_fcurves(obj.animation_data)) > 0
     ):
-        fcurve = findFCurveByPath(obj.animation_data.action.fcurves, path)
+        fcurve = findFCurveByPath(get_action_fcurves(obj.animation_data), path)
 
         if fcurve:
             # find keyframe
@@ -308,14 +312,11 @@ class OBJECT_OT_remove_xplane_dataref(bpy.types.Operator):
         path = getDatarefValuePath(self.index)
 
         # remove FCurves too
-        if (
-            obj.animation_data != None
-            and obj.animation_data.action != None
-            and len(obj.animation_data.action.fcurves) > 0
-        ):
-            fcurve = findFCurveByPath(obj.animation_data.action.fcurves, path)
+        fcurves = get_action_fcurves(obj.animation_data)
+        if fcurves:
+            fcurve = findFCurveByPath(fcurves, path)
             if fcurve:
-                obj.animation_data.action.fcurves.remove(fcurve=fcurve)
+                fcurves.remove(fcurve=fcurve)
 
         return {"FINISHED"}
 
@@ -336,8 +337,7 @@ class OBJECT_OT_add_xplane_dataref_keyframe(bpy.types.Operator):
         path = getDatarefValuePath(self.index)
         value = obj.xplane.datarefs[self.index].value
 
-        if "XPlane Datarefs" not in obj.animation_data.action.groups:
-            obj.animation_data.action.groups.new("XPlane Datarefs")
+        ensure_action_group(obj.animation_data, "XPlane Datarefs")
 
         obj.xplane.datarefs[self.index].keyframe_insert(
             data_path="value", group="XPlane Datarefs"
@@ -449,14 +449,11 @@ class BONE_OT_remove_xplane_dataref(bpy.types.Operator):
         path = getDatarefValuePath(self.index, bone)
 
         # remove FCurves too
-        if (
-            obj.animation_data != None
-            and obj.animation_data.action != None
-            and len(obj.animation_data.action.fcurves) > 0
-        ):
-            fcurve = findFCurveByPath(obj.animation_data.action.fcurves, path)
+        fcurves = get_action_fcurves(obj.animation_data)
+        if fcurves:
+            fcurve = findFCurveByPath(fcurves, path)
             if fcurve:
-                obj.animation_data.action.fcurves.remove(fcurve=fcurve)
+                fcurves.remove(fcurve=fcurve)
 
         return {"FINISHED"}
 
@@ -484,8 +481,7 @@ class BONE_OT_add_xplane_dataref_keyframe(bpy.types.Operator):
 
         groupName = "XPlane Datarefs " + bone.name
 
-        if groupName not in armature.animation_data.action.groups:
-            armature.animation_data.action.groups.new(groupName)
+        ensure_action_group(armature.animation_data, groupName)
 
         armature.data.keyframe_insert(data_path=path, group=groupName)
 

--- a/io_xplane2blender/xplane_types/xplane_bone.py
+++ b/io_xplane2blender/xplane_types/xplane_bone.py
@@ -34,7 +34,7 @@ import mathutils
 
 from io_xplane2blender import xplane_constants, xplane_props
 from io_xplane2blender.xplane_config import getDebug
-from io_xplane2blender.xplane_helpers import floatToStr, logger, vec_b_to_x
+from io_xplane2blender.xplane_helpers import floatToStr, get_action_fcurves, logger, vec_b_to_x
 from io_xplane2blender.xplane_types.xplane_keyframe import XPlaneKeyframe
 from io_xplane2blender.xplane_types.xplane_keyframe_collection import (
     XPlaneKeyframeCollection,
@@ -183,13 +183,13 @@ class XPlaneBone:
                 # bone animation data resides in the armature objects .data block
                 fcurves = [
                     f
-                    for f in blenderObject.data.animation_data.action.fcurves
+                    for f in get_action_fcurves(blenderObject.data.animation_data)
                     if f.data_path.startswith(f'bones["{bone.name}"].xplane.datarefs')
                 ]
             else:
                 fcurves = [
                     f
-                    for f in blenderObject.animation_data.action.fcurves
+                    for f in get_action_fcurves(blenderObject.animation_data)
                     if f.data_path.startswith(f"xplane.datarefs")
                 ]
         except AttributeError:

--- a/io_xplane2blender/xplane_types/xplane_file.py
+++ b/io_xplane2blender/xplane_types/xplane_file.py
@@ -34,6 +34,7 @@ from ..xplane_helpers import (
     ExportableRoot,
     PotentialRoot,
     floatToStr,
+    iter_all_action_fcurves,
     logger,
 )
 from .xplane_bone import XPlaneBone
@@ -181,7 +182,7 @@ def _pre_scan_all_keyframes():
         {
             int(kf.co[0])
             for action in bpy.data.actions
-            for fcurve in action.fcurves
+            for fcurve in iter_all_action_fcurves(action)
             for kf in fcurve.keyframe_points
             if kf.co[0].is_integer()
         }

--- a/tests/features/rain/bake_wiper_texture_bad_rgb_only.test.py
+++ b/tests/features/rain/bake_wiper_texture_bad_rgb_only.test.py
@@ -23,6 +23,6 @@ class TestBakeWiperTextureBadRGBOnly(XPlaneTestCase):
             "bad_wiper_image_rgb_only"
         ]
         bpy.context.view_layer.objects.active = any_object
-        self.assertEquals(bpy.ops.xplane.bake_wiper_gradient_texture(), {"CANCELLED"})
+        self.assertEqual(bpy.ops.xplane.bake_wiper_gradient_texture(), {"CANCELLED"})
 
 runTestCases([TestBakeWiperTextureBadRGBOnly])


### PR DESCRIPTION
Blender 5.0 removed action.fcurves and action.groups in favour of the new slotted actions API (ActionChannelbag). Added three compat helpers to xplane_helpers.py (get_action_fcurves, iter_all_action_fcurves, ensure_action_group) and update all call sites in xplane_ops.py, xplane_bone.py, and xplane_file.py. Also replace deprecated assertEquals with assertEqual throughout the test suite (removed in Python 3.12, which ships with Blender 5.x). Possibly Closes #758.